### PR TITLE
Feature/234 lazy loading images

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -52,35 +52,37 @@ import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatGridListModule} from '@angular/material/grid-list';
+import {ShopLogoComponent} from './shop-logo/shop-logo.component';
 
 @NgModule({
   declarations: [
+    AdminDetailsPageComponent,
+    AdminLayoutComponent,
     AdminLoginPageComponent,
     AdminOverviewPageComponent,
-    AdminDetailsPageComponent,
     AppComponent,
     AppFooterComponent,
     AppHeaderComponent,
     BookingPopupComponent,
     CancelReservationComponent,
+    ContactTypesComponent,
     ImprintPageComponent,
+    LandingLayoutComponent,
     LandingPageComponent,
     LoginFormComponent,
     LoginPageComponent,
+    NormalLayoutComponent,
     PasswordResetPageComponent,
     PasswordResetPopupComponent,
     PrivacyPageComponent,
     RegisterBusinessPopupComponent,
     ShopCreationPageComponent,
     ShopCreationSuccessPopupComponent,
-    ShopDetailsPageComponent,
-    ShopManagementPageComponent,
-    ShopSearchPageComponent,
     ShopDetailsConfigComponent,
-    ContactTypesComponent,
-    NormalLayoutComponent,
-    LandingLayoutComponent,
-    AdminLayoutComponent
+    ShopDetailsPageComponent,
+    ShopLogoComponent,
+    ShopManagementPageComponent,
+    ShopSearchPageComponent
   ],
   imports: [
     AppRoutingModule,
@@ -96,6 +98,7 @@ import {MatGridListModule} from '@angular/material/grid-list';
     MatDividerModule,
     MatExpansionModule,
     MatFormFieldModule,
+    MatGridListModule,
     MatIconModule,
     MatInputModule,
     MatPasswordStrengthModule,
@@ -108,8 +111,7 @@ import {MatGridListModule} from '@angular/material/grid-list';
     MatTabsModule,
     MatToolbarModule,
     ReactiveFormsModule,
-    SimpleNotificationsModule.forRoot(),
-    MatGridListModule
+    SimpleNotificationsModule.forRoot()
   ],
   providers: [
     {provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: {hasBackdrop: false}},

--- a/frontend/src/app/layouts/normal-layout/normal-layout.component.css
+++ b/frontend/src/app/layouts/normal-layout/normal-layout.component.css
@@ -1,3 +1,9 @@
 .app-content {
   max-width: 960px;
 }
+
+@media screen and (max-width: 719px) {
+  .app-content {
+    max-width: 100vw;
+  }
+}

--- a/frontend/src/app/shop-logo/shop-logo.component.css
+++ b/frontend/src/app/shop-logo/shop-logo.component.css
@@ -1,0 +1,4 @@
+.shop-logo {
+  width: 100%;
+  height: auto;
+}

--- a/frontend/src/app/shop-logo/shop-logo.component.ts
+++ b/frontend/src/app/shop-logo/shop-logo.component.ts
@@ -1,0 +1,21 @@
+import {Component, Input} from '@angular/core';
+
+@Component({
+  selector: 'shop-logo',
+  template: `<img [ngClass]="logoClass" [src]="src" alt="Shop logo" [attr.loading]="'lazy'" class="shop-logo">`,
+  styleUrls: ['./shop-logo.component.css']
+})
+export class ShopLogoComponent {
+
+  @Input()
+  imageUrl: string;
+
+  get logoClass() {
+    return !!this.imageUrl ? 'shop-logo' : 'default-logo';
+  }
+
+  get src() {
+    return !!this.imageUrl ? this.imageUrl : 'assets/default-logo.svg';
+  }
+
+}

--- a/frontend/src/app/shop-search-page/shop-search-page.component.css
+++ b/frontend/src/app/shop-search-page/shop-search-page.component.css
@@ -1,20 +1,10 @@
-tr:not(.example-expanded-row):hover {
-  background: whitesmoke;
-}
-
-.mat-column-supportedContactTypes {
-  flex: 0 0 40% !important;
-  width: 40% !important;
-}
-
-.mat-column-distance {
-  flex: 0 0 10% !important;
-  width: 10% !important;
-}
-
 .align-baseline {
   display: flex;
   align-items: baseline
+}
+
+.search-field {
+  width: 75%;
 }
 
 .zip-code-div {
@@ -28,64 +18,41 @@ tr:not(.example-expanded-row):hover {
   line-height: 1;
 }
 
-.search-field {
-  width: 75%;
-}
-
-.hide {
-  visibility: hidden;
-}
-
-.shop-logo {
-  max-width: 80px;
-  max-height: 80px;
-  display: block;
-}
-
-.default-logo {
-  height: 80px;
-}
-
-.shop-titel {
-  justify-content: start;
-}
-
-.shop-overview {
+.shop {
   display: flex;
+}
+
+.meta {
+  width: 60%;
+  display: flex;
+}
+
+.shop-logo-container, .shop-text {
+  flex-shrink: 0;
+}
+
+.shop-logo-container {
+  width: 100px;
+  max-height: 100px;
+}
+
+.shop-text {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   align-items: flex-start;
-  justify-content: space-between;
-  padding-left: 2%;
+  max-width: calc(100% - 101px);
 }
 
-.image-and-shop {
-  display: flex;
-  align-items: center;
+.shop-text > div {
+  width: 100%;
+  word-break: break-word;
 }
 
 .shop-contact-types {
   width: 40%;
-  min-width: 350px;
 }
-
-.shop-text {
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  height: 80px;
-  min-width: 250px;
-  margin-left: 12px;
-  margin-right: 24px;
-}
-
-.divider {
-  margin-left: 12px;
-  height: 80px;
-}
-
-.mat-card-actions, .mat-card-subtitle, .mat-card-content {
-  margin-bottom: 0px;
-}
-
 
 /* styles for small devices */
 @media screen and (max-width: 719px) {
@@ -107,13 +74,20 @@ tr:not(.example-expanded-row):hover {
     order: 2;
   }
 
-  .shop-overview {
-    flex-direction: column;
-    width: 90vw;
+  .shop {
+    display: block;
+  }
+
+  .meta, .shop-contact-types {
+    width: 100%;
+  }
+
+  .shop-logo-container {
+    width: 60px;
+    max-height: 60px;
   }
 
   .shop-text {
-    padding-bottom: 15px;
+    max-width: calc(100% - 60px - 16px);
   }
-
 }

--- a/frontend/src/app/shop-search-page/shop-search-page.component.html
+++ b/frontend/src/app/shop-search-page/shop-search-page.component.html
@@ -31,46 +31,36 @@
     </div>
   </div>
 
-  <div class="text-no-values" style="width: 90vw;" *ngIf="isSearchEmpty">
-    <p>
-      Leider haben wir keine Ergebnisse zu Ihrer Suche nach '{{ lastSearchString }}' gefunden.
-    </p>
+  <div class="text-no-values padding-horizontal" *ngIf="isSearchEmpty">
+    Leider haben wir keine Ergebnisse zu Ihrer Suche nach '{{ lastSearchString }}' gefunden.
   </div>
 
-  <div [ngClass]="{'hide': isSearchEmpty}">
-    <div class="margin-top"
-         *ngFor="let shop of sortShopsForMobile()"
-         (click)="showDetailPage({id: shop.id})">
+  <div *ngIf="!isSearchEmpty">
 
-      <mat-card class="mat-elevation-z5 clickable highlightable">
-        <mat-card-header>
-          <mat-card-title class="margin-vertical">
-            <div class="shop-overview">
-              <div class="image-and-shop">
-                <img [ngClass]="{'shop-logo' : shop.imageUrl, 'default-logo': !shop.imageUrl}"
-                     src="{{ shop.imageUrl? shop.imageUrl : 'assets/default-logo.svg' }}"
-                     alt="Shop logo">
-
-                <mat-divider [vertical]="true" class="divider"></mat-divider>
-
-                <div class="shop-text">
-                  <span style="padding-bottom: 10px;">{{ shop.name }}</span>
-
-                  <mat-card-subtitle>
-                    <span>{{shop.distance.toFixed(0)}} km entfernt</span>
-                  </mat-card-subtitle>
-                </div>
-              </div>
-
-              <mat-card-content class="shop-contact-types">
-                <contact-types [availableContactTypes]="shop.supportedContactTypes"></contact-types>
-              </mat-card-content>
+    <mat-card class="mat-elevation-z5 clickable highlightable margin-top"
+              *ngFor="let shop of shops" (click)="showDetailPage({id: shop.id})">
+      <mat-card-content>
+        <div class="shop">
+          <div class="meta" [class.margin-bottom]="isSmallScreen">
+            <div class="shop-logo-container" [class.padding-horizontal]="!isSmallScreen">
+              <shop-logo [imageUrl]="shop.imageUrl"></shop-logo>
             </div>
-          </mat-card-title>
-        </mat-card-header>
-      </mat-card>
 
-    </div>
+            <mat-divider [vertical]="true" class="divider" *ngIf="!isSmallScreen"></mat-divider>
+
+            <div class="shop-text" [class.padding-horizontal]="!isSmallScreen" [class.padding-left]="isSmallScreen">
+              <div class="mat-card-title">{{ shop.name }}</div>
+              <div class="mat-card-subtitle">{{ shop.distance.toFixed(0) }} km entfernt</div>
+            </div>
+          </div>
+
+          <div class="shop-contact-types" [class.margin-bottom]="isSmallScreen">
+            <contact-types [availableContactTypes]="shop.supportedContactTypes"></contact-types>
+          </div>
+        </div>
+      </mat-card-content>
+    </mat-card>
+
   </div>
 
 </div>

--- a/frontend/src/app/shop-search-page/shop-search-page.component.html
+++ b/frontend/src/app/shop-search-page/shop-search-page.component.html
@@ -2,49 +2,66 @@
   <div class="align-baseline">
     <mat-form-field class="search-field">
       <mat-label>Wonach suchen Sie heute?</mat-label>
+
       <input
         matInput
         placeholder="Suchen Sie nach Ihrem Lieblingsgeschäft oder nach Begriffen wie Kaffee, Optiker, ..."
         [(ngModel)]="searchBusiness"
-        (keyup)="handleKeyEvent($event)"/>
+        (keyup)="handleKeyEvent($event)"
+      />
+
       <a (click)="performSearch()" matSuffix>
         <mat-icon>search</mat-icon>
       </a>
     </mat-form-field>
+
     <div class="zip-code-div">
       Läden in der Nähe von
       <mat-form-field class="zip-code-field">
-        <input matInput type="text"
-               (keyup)="checkZipCodeInput($event)" maxlength="5" minlength="5"
+        <input type="text"
+               minlength="5"
+               maxlength="5"
+               matInput
+               (keyup)="checkZipCodeInput($event)"
                [(ngModel)]="newLocation"
                (click)="selectAll($event)"
-               (keyup)="handleKeyEvent($event)"/></mat-form-field>
+               (keyup)="handleKeyEvent($event)"
+        />
+      </mat-form-field>
     </div>
   </div>
 
-  <div class="text-no-values" style="width: 90vw;"><p *ngIf="isSearchEmpty">Leider haben wir keine Ergebnisse zu Ihrer
-    Suche nach '{{lastSearchString}}' gefunden.</p>
+  <div class="text-no-values" style="width: 90vw;" *ngIf="isSearchEmpty">
+    <p>
+      Leider haben wir keine Ergebnisse zu Ihrer Suche nach '{{ lastSearchString }}' gefunden.
+    </p>
   </div>
+
   <div [ngClass]="{'hide': isSearchEmpty}">
     <div class="margin-top"
-         *ngFor="let shop of sortShopsForMobile(); last as last"
+         *ngFor="let shop of sortShopsForMobile()"
          (click)="showDetailPage({id: shop.id})">
+
       <mat-card class="mat-elevation-z5 clickable highlightable">
         <mat-card-header>
-          <mat-card-title class="margin-vertical" id="title">
+          <mat-card-title class="margin-vertical">
             <div class="shop-overview">
               <div class="image-and-shop">
-                <img [ngClass]="{'shop-logo' : shop.imageUrl, 'default-logo': !shop.imageUrl}" src=
-                  "{{shop.imageUrl? shop.imageUrl : 'assets/default-logo.svg'}}"
+                <img [ngClass]="{'shop-logo' : shop.imageUrl, 'default-logo': !shop.imageUrl}"
+                     src="{{ shop.imageUrl? shop.imageUrl : 'assets/default-logo.svg' }}"
                      alt="Shop logo">
+
                 <mat-divider [vertical]="true" class="divider"></mat-divider>
+
                 <div class="shop-text">
                   <span style="padding-bottom: 10px;">{{ shop.name }}</span>
+
                   <mat-card-subtitle>
                     <span>{{shop.distance.toFixed(0)}} km entfernt</span>
                   </mat-card-subtitle>
                 </div>
               </div>
+
               <mat-card-content class="shop-contact-types">
                 <contact-types [availableContactTypes]="shop.supportedContactTypes"></contact-types>
               </mat-card-content>
@@ -52,8 +69,8 @@
           </mat-card-title>
         </mat-card-header>
       </mat-card>
-    </div>
 
+    </div>
   </div>
 
 </div>

--- a/frontend/src/app/shop-search-page/shop-search-page.component.ts
+++ b/frontend/src/app/shop-search-page/shop-search-page.component.ts
@@ -63,8 +63,10 @@ export class ShopSearchPageComponent implements OnInit {
 
   private handleResponse(response) {
     if (response.shops.length > 0) {
-      this.shops = response.shops;
+      this.shops = [...response.shops]
+        .sort((shop1, shop2) => shop1.distance - shop2.distance);
       this.isSearchEmpty = false;
+
     } else {
       this.shops = [];
       console.log('Keine Läden gefunden.');
@@ -120,10 +122,6 @@ export class ShopSearchPageComponent implements OnInit {
   selectAll($event: MouseEvent) {
     const input = $event.target as HTMLInputElement;
     input.select();
-  }
-
-  sortShopsForMobile() {
-    return this.shops.sort((shop1, shop2) => shop1.distance - shop2.distance);
   }
 
   handleKeyEvent($event: KeyboardEvent) {


### PR DESCRIPTION
Did all kinds of cleaning up - especially in the ShopSearch component. Goal was to simplify the HTML a bit as well as move the whole "which image shall I load" handling into a dedicated component.

The `loading` attribute is also properly set on the `img` tags now. So it **should** work just fine in modern browser automatically.

The attribute does no harm if the browser doesn't understand it (it simply gets ignored).

So in an environment with lots of different pictures (e.g. TEST?) it should be possible to analyze the lazy behavior.