### PR TITLE
Feature/shop details refactoring

### DIFF
--- a/frontend/src/app/shop-details-page/shop-details-page.component.css
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.css
@@ -31,6 +31,15 @@
   padding-bottom: 25px;
 }
 
+.social-links-block-small {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 120px);
+  justify-content: center;
+  padding-top: 10px;
+  padding-bottom: 25px;
+}
+
+
 .book-button {
   width: 100%;
 }

--- a/frontend/src/app/shop-details-page/shop-details-page.component.css
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.css
@@ -7,6 +7,10 @@
   text-decoration: none;
 }
 
+.address-title {
+  font-weight: bold;
+}
+
 .social-links {
   padding-right: 15px;
   padding-top: 10px;

--- a/frontend/src/app/shop-details-page/shop-details-page.component.css
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.css
@@ -9,6 +9,7 @@
 
 .social-links {
   padding-right: 15px;
+  padding-top: 10px;
   display: flex;
   align-items: end;
 }
@@ -19,6 +20,14 @@
   width: 25px;
   /* set png color */
   filter: invert(20%) sepia(34%) saturate(4623%) hue-rotate(246deg) brightness(90%) contrast(99%);
+}
+
+.social-links-block {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  padding-top: 10px;
 }
 
 .book-button {

--- a/frontend/src/app/shop-details-page/shop-details-page.component.css
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.css
@@ -11,6 +11,10 @@
   font-weight: bold;
 }
 
+.booking-title {
+  padding-top: 25px;
+}
+
 .social-links {
   padding-right: 15px;
   padding-top: 10px;

--- a/frontend/src/app/shop-details-page/shop-details-page.component.css
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.css
@@ -28,10 +28,31 @@
   align-items: flex-end;
   flex-wrap: wrap;
   padding-top: 10px;
+  padding-bottom: 25px;
 }
 
 .book-button {
   width: 100%;
+}
+
+.shop-details-card-image-container {
+  width: 160px;
+  height: 160px;
+  transform: translate(-20%, 50%);
+  position: absolute;
+  left: 80%;
+  margin-top: -160px;
+  border-radius: 50%;
+  border: 0;
+  background-color: #ffffff;
+  z-index: 2;
+}
+
+.shop-details-card-image {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
 }
 
 .small-booking-row {
@@ -68,6 +89,14 @@
   max-height: 180px;
   display: block;
 }
+
+.shop-logo-small {
+  max-width: 120px;
+  max-height: 180px;
+  display: block;
+  margin: auto;
+}
+
 
 .shop-logo-svg {
   height: 120px;

--- a/frontend/src/app/shop-details-page/shop-details-page.component.html
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.html
@@ -50,6 +50,15 @@
               Twitter</a>
           </div>
         </div>
+        <mat-divider></mat-divider>
+        <div class="booking-title">
+          <h3>Terminbuchung</h3>
+          <p>Wählen Sie jetzt Ihren Wunschzeitpunkt aus und {{ shop.name }} ruft Sie für Ihr persönliches
+            Beratungsgespräch
+            an<span *ngIf="!hasOnlyPhone"> - per Videochat direkt aus dem Laden</span>. <span
+              *ngIf="hasOnlyPhone">{{ shop.name }}
+              bietet derzeit noch keine Videoberatung an, Sie können sich aber per Telefon beraten lassen.</span></p>
+        </div>
         <mat-tab-group>
           <mat-tab *ngFor="let slots of slotsPerDay">
             <ng-template mat-tab-label>
@@ -60,7 +69,6 @@
               <h3 *ngIf="!slots.hasSlots" class="text-no-values margin-top">
                 Dieser Laden bietet am {{slots.dayName}} leider keine Termine an.
               </h3>
-
               <div *ngIf="slots.hasSlots">
                 <mat-table [dataSource]="slots.slots" class="margin-top" id="calendar">
                   <ng-container matColumnDef="from">
@@ -155,6 +163,15 @@
             <img src="../assets/twitter.png" class="social-links-logo">
             Twitter</a>
         </div>
+      </div>
+      <mat-divider></mat-divider>
+      <div class="booking-title">
+        <h3>Terminbuchung</h3>
+        <p>Wählen Sie jetzt Ihren Wunschzeitpunkt aus und {{ shop.name }} ruft Sie für Ihr persönliches
+          Beratungsgespräch
+          an<span *ngIf="!hasOnlyPhone"> - per Videochat direkt aus dem Laden</span>. <span
+            *ngIf="hasOnlyPhone">{{ shop.name }}
+            bietet derzeit noch keine Videoberatung an, Sie können sich aber per Telefon beraten lassen.</span></p>
       </div>
       <mat-accordion>
         <mat-expansion-panel *ngFor="let slots of slotsPerDay" [expanded]="slots == activatedSlot"

--- a/frontend/src/app/shop-details-page/shop-details-page.component.html
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.html
@@ -16,7 +16,8 @@
           <mat-card-subtitle>
             <div *ngIf="!hasDescription">Dieser Laden hat noch keine Beschreibung hinterlegt.</div>
             <div *ngIf="hasDescription">{{ shop.details }}</div>
-            <div style="display: flex; justify-content: flex-start; align-items: flex-end; padding-top: 10px;">
+            <div
+              style="display: flex; justify-content: flex-start; align-items: flex-end; flex-wrap: wrap; padding-top: 10px;">
               <div *ngIf="shop.website" class="social-links">
                 <a href="{{returnValidLink(shop.website)}}" target="_blank" class="social-links"
                    style="padding-left: 5px;">

--- a/frontend/src/app/shop-details-page/shop-details-page.component.html
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.html
@@ -8,24 +8,128 @@
     </button>
   </div>
 
-  <div *ngIf="shop.imageUrl" class="shop-details-card-image-container mat-elevation-z5 only-large">
-    <img src="{{shop.imageUrl}}" alt="Shop Logo" class="shop-logo shop-details-card-image">
+  <!--  ONLY LARGE LAYOUT-->
+  <div class="only-large">
+    <div *ngIf="shop.imageUrl" class="shop-details-card-image-container mat-elevation-z5">
+      <img src="{{shop.imageUrl}}" alt="Shop Logo" class="shop-logo shop-details-card-image">
+    </div>
+    <mat-card class="mat-elevation-z5">
+      <mat-card-header>
+        <div class="shop-header">
+          <div class="shop-details-header">
+            <mat-card-title class="margin-vertical" id="title">{{ shop.name }}</mat-card-title>
+          </div>
+        </div>
+      </mat-card-header>
+      <mat-card-content>
+        <div *ngIf="!hasDescription">Dieser Laden hat noch keine Beschreibung hinterlegt.</div>
+        <div *ngIf="hasDescription" style="padding-top: 25px">{{ shop.details }}</div>
+        <div class="social-links-block">
+          <div *ngIf="shop.website" class="social-links">
+            <a href="{{returnValidLink(shop.website)}}" target="_blank" class="social-links"
+               style="padding-left: 5px;">
+              <img src="../assets/web.png" class="social-links-logo">
+              Website</a>
+          </div>
+          <div *ngIf="shop.socialLinks.facebook" class="social-links">
+            <a href="{{returnValidFacebookLink(shop.socialLinks.facebook)}}" target="_blank" class="social-links"
+               style="padding-left: 5px;">
+              <img src="../assets/facebook.png" class="social-links-logo">
+              Facebook</a>
+          </div>
+          <div *ngIf="shop.socialLinks.instagram" class="social-links">
+            <a href="{{returnValidInstagramLink(shop.socialLinks.instagram)}}" target="_blank" class="social-links"
+               style="padding-left: 5px;">
+              <img src="../assets/instagram.png" class="social-links-logo">
+              Instagram</a>
+          </div>
+          <div *ngIf="shop.socialLinks.twitter" class="social-links">
+            <a href="{{returnValidTwitterLink(shop.socialLinks.twitter)}}" target="_blank" class="social-links"
+               style="padding-left: 5px;">
+              <img src="../assets/twitter.png" class="social-links-logo">
+              Twitter</a>
+          </div>
+        </div>
+        <mat-tab-group>
+          <mat-tab *ngFor="let slots of slotsPerDay">
+            <ng-template mat-tab-label>
+              <div (click)="activatedSlot = slots"
+                   [ngClass]="!slots.hasSlots? 'not-open' : ''">{{slots.dayName}}</div>
+            </ng-template>
+            <ng-template matTabContent>
+              <h3 *ngIf="!slots.hasSlots" class="text-no-values margin-top">
+                Dieser Laden bietet am {{slots.dayName}} leider keine Termine an.
+              </h3>
+
+              <div *ngIf="slots.hasSlots">
+                <mat-table [dataSource]="slots.slots" class="margin-top" id="calendar">
+                  <ng-container matColumnDef="from">
+                    <mat-header-cell *matHeaderCellDef> Start</mat-header-cell>
+                    <mat-cell *matCellDef="let element">{{element.start}}</mat-cell>
+                  </ng-container>
+
+                  <ng-container matColumnDef="to">
+                    <mat-header-cell *matHeaderCellDef> Ende</mat-header-cell>
+                    <mat-cell *matCellDef="let element">{{element.end}}</mat-cell>
+                  </ng-container>
+
+                  <ng-container matColumnDef="available">
+                    <mat-header-cell *matHeaderCellDef> Verfügbar</mat-header-cell>
+                    <mat-cell *matCellDef="let element">
+                      <button class="book-button"
+                              mat-raised-button
+                              *ngIf="element.available"
+                              (click)="showBookingPopup(element.id)"
+                              color="primary">
+                        Jetzt buchen
+                      </button>
+
+                      <button class="book-button" mat-stroked-button *ngIf="!element.available" disabled>
+                        Belegt
+                      </button>
+                    </mat-cell>
+                  </ng-container>
+
+                  <mat-header-row *matHeaderRowDef="['from', 'to', 'available']"></mat-header-row>
+                  <mat-row *matRowDef="let row; columns: ['from', 'to', 'available']"></mat-row>
+                </mat-table>
+              </div>
+
+
+            </ng-template>
+          </mat-tab>
+        </mat-tab-group>
+        <div class="shop-details margin-big-vertical">
+          <div>
+            <div>{{shop.name}}</div>
+            <div>{{shop.street}} {{shop.addressSupplement}}</div>
+            <div>{{shop.zipCode}} {{shop.city}}</div>
+            <div><a href="mailto:{{shop.email}}">{{shop.email}}</a></div>
+          </div>
+
+          <div>
+            <contact-types [availableContactTypes]="shop.contactTypes"></contact-types>
+          </div>
+        </div>
+      </mat-card-content>
+    </mat-card>
   </div>
-  <mat-card class="mat-elevation-z5">
-    <div *ngIf="shop.imageUrl" class="only-small">
+  <!--  END LARGE LAYOUT-->
+
+  <!--  ONLY SMALL LAYOUT-->
+  <div class="only-small">
+    <div *ngIf="shop.imageUrl">
       <img src="{{shop.imageUrl}}" alt="Shop Logo" class="shop-logo-small shop-details-card-image-small">
     </div>
-    <mat-card-header>
-      <div class="shop-header">
-        <div class="shop-details-header">
-          <mat-card-title class="margin-vertical" id="title">{{ shop.name }}</mat-card-title>
-        </div>
+    <div class="shop-header">
+      <div class="shop-details-header">
+        <mat-card-title class="margin-vertical" id="title-small">{{ shop.name }}</mat-card-title>
       </div>
-    </mat-card-header>
+    </div>
     <mat-card-content>
       <div *ngIf="!hasDescription">Dieser Laden hat noch keine Beschreibung hinterlegt.</div>
       <div *ngIf="hasDescription" style="padding-top: 25px">{{ shop.details }}</div>
-      <div class="social-links-block">
+      <div class="social-links-block-small">
         <div *ngIf="shop.website" class="social-links">
           <a href="{{returnValidLink(shop.website)}}" target="_blank" class="social-links"
              style="padding-left: 5px;">
@@ -51,59 +155,6 @@
             Twitter</a>
         </div>
       </div>
-      <div class="only-large">
-        <mat-tab-group>
-          <mat-tab *ngFor="let slots of slotsPerDay">
-            <ng-template mat-tab-label>
-              <div (click)="activatedSlot = slots"
-                   [ngClass]="!slots.hasSlots? 'not-open' : ''">{{slots.dayName}}</div>
-            </ng-template>
-            <ng-template matTabContent>
-              <h3 *ngIf="!slots.hasSlots" class="text-no-values margin-top">
-                Dieser Laden bietet am {{slots.dayName}} leider keine Termine an.
-            </h3>
-
-            <div *ngIf="slots.hasSlots">
-              <mat-table [dataSource]="slots.slots" class="margin-top" id="calendar">
-                <ng-container matColumnDef="from">
-                  <mat-header-cell *matHeaderCellDef> Start</mat-header-cell>
-                  <mat-cell *matCellDef="let element">{{element.start}}</mat-cell>
-                </ng-container>
-
-                <ng-container matColumnDef="to">
-                  <mat-header-cell *matHeaderCellDef> Ende</mat-header-cell>
-                  <mat-cell *matCellDef="let element">{{element.end}}</mat-cell>
-                </ng-container>
-
-                <ng-container matColumnDef="available">
-                  <mat-header-cell *matHeaderCellDef> Verfügbar</mat-header-cell>
-                  <mat-cell *matCellDef="let element">
-                    <button class="book-button"
-                            mat-raised-button
-                            *ngIf="element.available"
-                            (click)="showBookingPopup(element.id)"
-                            color="primary">
-                      Jetzt buchen
-                    </button>
-
-                    <button class="book-button" mat-stroked-button *ngIf="!element.available" disabled>
-                      Belegt
-                    </button>
-                  </mat-cell>
-                </ng-container>
-
-                <mat-header-row *matHeaderRowDef="['from', 'to', 'available']"></mat-header-row>
-                <mat-row *matRowDef="let row; columns: ['from', 'to', 'available']"></mat-row>
-              </mat-table>
-            </div>
-
-
-          </ng-template>
-        </mat-tab>
-      </mat-tab-group>
-    </div>
-    <!-- ONLY SMALL -->
-    <div class="only-small">
       <mat-accordion>
         <mat-expansion-panel *ngFor="let slots of slotsPerDay" [expanded]="slots == activatedSlot"
                              (opened)="activatedSlot = slots">
@@ -137,19 +188,19 @@
           </div>
         </mat-expansion-panel>
       </mat-accordion>
-    </div>
-    <div class="shop-details margin-big-vertical">
+      <div class="shop-details margin-big-vertical">
+        <div>
+          <contact-types [availableContactTypes]="shop.contactTypes"></contact-types>
+        </div>
+      </div>
       <div>
         <div>{{shop.name}}</div>
         <div>{{shop.street}} {{shop.addressSupplement}}</div>
         <div>{{shop.zipCode}} {{shop.city}}</div>
         <div><a href="mailto:{{shop.email}}">{{shop.email}}</a></div>
       </div>
-
-      <div>
-        <contact-types [availableContactTypes]="shop.contactTypes"></contact-types>
-      </div>
-    </div>
     </mat-card-content>
-  </mat-card>
+
+  </div>
+  <!--  END SMALL LAYOUT-->
 </div>

--- a/frontend/src/app/shop-details-page/shop-details-page.component.html
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.html
@@ -8,60 +8,59 @@
     </button>
   </div>
 
+  <div *ngIf="shop.imageUrl" class="shop-details-card-image-container mat-elevation-z5 only-large">
+    <img src="{{shop.imageUrl}}" alt="Shop Logo" class="shop-logo shop-details-card-image">
+  </div>
   <mat-card class="mat-elevation-z5">
+    <div *ngIf="shop.imageUrl" class="only-small">
+      <img src="{{shop.imageUrl}}" alt="Shop Logo" class="shop-logo-small shop-details-card-image-small">
+    </div>
     <mat-card-header>
       <div class="shop-header">
         <div class="shop-details-header">
           <mat-card-title class="margin-vertical" id="title">{{ shop.name }}</mat-card-title>
-          <mat-card-subtitle>
-            <div *ngIf="!hasDescription">Dieser Laden hat noch keine Beschreibung hinterlegt.</div>
-            <div *ngIf="hasDescription">{{ shop.details }}</div>
-            <div class="social-links-block">
-              <div *ngIf="shop.website" class="social-links">
-                <a href="{{returnValidLink(shop.website)}}" target="_blank" class="social-links"
-                   style="padding-left: 5px;">
-                  <img src="../assets/web.png" class="social-links-logo">
-                  Website</a>
-              </div>
-              <div *ngIf="shop.socialLinks.facebook" class="social-links">
-                <a href="{{returnValidFacebookLink(shop.socialLinks.facebook)}}" target="_blank" class="social-links"
-                   style="padding-left: 5px;">
-                  <img src="../assets/facebook.png" class="social-links-logo">
-                  Facebook</a>
-              </div>
-              <div *ngIf="shop.socialLinks.instagram" class="social-links">
-                <a href="{{returnValidInstagramLink(shop.socialLinks.instagram)}}" target="_blank" class="social-links"
-                   style="padding-left: 5px;">
-                  <img src="../assets/instagram.png" class="social-links-logo">
-                  Instagram</a>
-              </div>
-              <div *ngIf="shop.socialLinks.twitter" class="social-links">
-                <a href="{{returnValidTwitterLink(shop.socialLinks.twitter)}}" target="_blank" class="social-links"
-                   style="padding-left: 5px;">
-                  <img src="../assets/twitter.png" class="social-links-logo">
-                  Twitter</a>
-              </div>
-            </div>
-          </mat-card-subtitle>
-        </div>
-        <div class="shop-logo-container">
-          <img [ngClass]="shop.imageUrl? 'shop-logo' : 'shop-logo-svg'" src=
-            "{{shop.imageUrl? shop.imageUrl : '../assets/default-logo.svg'}}"
-               alt="Shop logo">
         </div>
       </div>
     </mat-card-header>
-
-    <div class="only-large">
-      <mat-tab-group>
-        <mat-tab *ngFor="let slots of slotsPerDay">
-          <ng-template mat-tab-label>
-            <div (click)="activatedSlot = slots"
-                 [ngClass]="!slots.hasSlots? 'not-open' : ''">{{slots.dayName}}</div>
-          </ng-template>
-          <ng-template matTabContent>
-            <h3 *ngIf="!slots.hasSlots" class="text-no-values margin-top">
-              Dieser Laden bietet am {{slots.dayName}} leider keine Termine an.
+    <mat-card-content>
+      <div *ngIf="!hasDescription">Dieser Laden hat noch keine Beschreibung hinterlegt.</div>
+      <div *ngIf="hasDescription" style="padding-top: 25px">{{ shop.details }}</div>
+      <div class="social-links-block">
+        <div *ngIf="shop.website" class="social-links">
+          <a href="{{returnValidLink(shop.website)}}" target="_blank" class="social-links"
+             style="padding-left: 5px;">
+            <img src="../assets/web.png" class="social-links-logo">
+            Website</a>
+        </div>
+        <div *ngIf="shop.socialLinks.facebook" class="social-links">
+          <a href="{{returnValidFacebookLink(shop.socialLinks.facebook)}}" target="_blank" class="social-links"
+             style="padding-left: 5px;">
+            <img src="../assets/facebook.png" class="social-links-logo">
+            Facebook</a>
+        </div>
+        <div *ngIf="shop.socialLinks.instagram" class="social-links">
+          <a href="{{returnValidInstagramLink(shop.socialLinks.instagram)}}" target="_blank" class="social-links"
+             style="padding-left: 5px;">
+            <img src="../assets/instagram.png" class="social-links-logo">
+            Instagram</a>
+        </div>
+        <div *ngIf="shop.socialLinks.twitter" class="social-links">
+          <a href="{{returnValidTwitterLink(shop.socialLinks.twitter)}}" target="_blank" class="social-links"
+             style="padding-left: 5px;">
+            <img src="../assets/twitter.png" class="social-links-logo">
+            Twitter</a>
+        </div>
+      </div>
+      <div class="only-large">
+        <mat-tab-group>
+          <mat-tab *ngFor="let slots of slotsPerDay">
+            <ng-template mat-tab-label>
+              <div (click)="activatedSlot = slots"
+                   [ngClass]="!slots.hasSlots? 'not-open' : ''">{{slots.dayName}}</div>
+            </ng-template>
+            <ng-template matTabContent>
+              <h3 *ngIf="!slots.hasSlots" class="text-no-values margin-top">
+                Dieser Laden bietet am {{slots.dayName}} leider keine Termine an.
             </h3>
 
             <div *ngIf="slots.hasSlots">
@@ -152,5 +151,6 @@
         <contact-types [availableContactTypes]="shop.contactTypes"></contact-types>
       </div>
     </div>
+    </mat-card-content>
   </mat-card>
 </div>

--- a/frontend/src/app/shop-details-page/shop-details-page.component.html
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.html
@@ -101,6 +101,7 @@
         </mat-tab-group>
         <div class="shop-details margin-big-vertical">
           <div>
+            <div class="address-title">Adresse</div>
             <div>{{shop.name}}</div>
             <div>{{shop.street}} {{shop.addressSupplement}}</div>
             <div>{{shop.zipCode}} {{shop.city}}</div>
@@ -194,6 +195,7 @@
         </div>
       </div>
       <div>
+        <div class="address-title">Adresse</div>
         <div>{{shop.name}}</div>
         <div>{{shop.street}} {{shop.addressSupplement}}</div>
         <div>{{shop.zipCode}} {{shop.city}}</div>

--- a/frontend/src/app/shop-details-page/shop-details-page.component.html
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.html
@@ -142,8 +142,7 @@
       <div>
         <div>{{shop.name}}</div>
         <div>{{shop.street}} {{shop.addressSupplement}}</div>
-        <div>{{shop.zipCode}}</div>
-        <div>{{shop.city}}</div>
+        <div>{{shop.zipCode}} {{shop.city}}</div>
         <div><a href="mailto:{{shop.email}}">{{shop.email}}</a></div>
       </div>
 

--- a/frontend/src/app/shop-details-page/shop-details-page.component.html
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.html
@@ -16,8 +16,7 @@
           <mat-card-subtitle>
             <div *ngIf="!hasDescription">Dieser Laden hat noch keine Beschreibung hinterlegt.</div>
             <div *ngIf="hasDescription">{{ shop.details }}</div>
-            <div
-              style="display: flex; justify-content: flex-start; align-items: flex-end; flex-wrap: wrap; padding-top: 10px;">
+            <div class="social-links-block">
               <div *ngIf="shop.website" class="social-links">
                 <a href="{{returnValidLink(shop.website)}}" target="_blank" class="social-links"
                    style="padding-left: 5px;">

--- a/frontend/src/app/shop-details-page/shop-details-page.component.ts
+++ b/frontend/src/app/shop-details-page/shop-details-page.component.ts
@@ -39,6 +39,11 @@ export class ShopDetailsPageComponent implements OnInit {
     return this.shop?.details?.trim().length > 0;
   }
 
+  get hasOnlyPhone(): boolean {
+    return (this.shop?.contactTypes?.length === 1 &&
+      this.shop?.contactTypes?.values()?.next()?.value === 'PHONE');
+  }
+
   shopId: string;
   shop: ShopDetailDto;
   activatedSlot: SlotsPerDay;


### PR DESCRIPTION
Eine größere Überarbeitung der Shop Details Page. Beinhaltet folgende Changes:

* Mobile und Desktop-Ansicht auseinandergezogen
* Auf Mobile: Die verschachtelten Karten wurden entfernt um etwas mehr Platz zu schaffen
* Logo in der Desktop-Ansicht in ein Circle Shape rechts oben an der Card verschoben
* Logo in der Mobile-Ansicht in die Karte hineingezogen
* Logo wird nur noch angezeigt, wenn es vorhanden ist. Auf der Detailseite macht der Platzhalter keinen Sinn.
* Social-Media-Icons brechen nun korrekt bei kleinen Layouts um
* Social-Media-Icons werden auf Mobile "am Raster ausgerichtet" dargestellt
* Terminbuchung um Hilfetext ergänzt, der erklärt wozu man den Termin bucht. Unterscheidet zwischen Läden, die nur Telefon anbieten und Läden, die auch Videochat anbieten.
* Adressblock gelayouted

@defaude Bitte im Review mein CSS überprüfen. Ich habe im Fall des Circles auf ::before verzichtet, damit ich das Bild dort sinnvoll in Angular hineinbekomme. Wenn es einen besseren Weg gibt, bin ich lernbegierig.