### PR TITLE
Add LogoutInterceptor

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -21,7 +21,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
 import {MatTableModule} from '@angular/material/table';
-import {HttpClientModule} from '@angular/common/http';
+import {HTTP_INTERCEPTORS, HttpClientModule} from '@angular/common/http';
 import {MatSortModule} from '@angular/material/sort';
 import {BookingPopupComponent} from './booking-popup/booking-popup.component';
 import {MAT_DIALOG_DEFAULT_OPTIONS, MatDialogModule} from '@angular/material/dialog';
@@ -53,6 +53,7 @@ import {MatProgressBarModule} from '@angular/material/progress-bar';
 import {MatToolbarModule} from '@angular/material/toolbar';
 import {MatGridListModule} from '@angular/material/grid-list';
 import {ShopLogoComponent} from './shop-logo/shop-logo.component';
+import {LogoutInterceptor} from './data/logout.interceptor';
 
 @NgModule({
   declarations: [
@@ -114,6 +115,7 @@ import {ShopLogoComponent} from './shop-logo/shop-logo.component';
     SimpleNotificationsModule.forRoot()
   ],
   providers: [
+    {provide: HTTP_INTERCEPTORS, useClass: LogoutInterceptor, multi: true},
     {provide: MAT_DIALOG_DEFAULT_OPTIONS, useValue: {hasBackdrop: false}},
     {provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher}
   ],

--- a/frontend/src/app/data/logout.interceptor.ts
+++ b/frontend/src/app/data/logout.interceptor.ts
@@ -1,0 +1,75 @@
+import {Injectable} from '@angular/core';
+import {HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
+import {Observable, throwError} from 'rxjs';
+import {catchError} from 'rxjs/operators';
+import {Router} from '@angular/router';
+import {AdminService} from '../shared/admin.service';
+import {ShopOwnerService} from '../shared/shop-owner.service';
+
+/**
+ * All 401'ed requests belonging to this base URL will trigger a redirect to the admin login page.
+ */
+const API_ADMIN_BASE = '/api/admin';
+
+/**
+ * These URLs will NOT trigger a redirect to the admin login page.
+ */
+const API_ADMIN_WHITELIST = [
+  '/api/admin/login'
+];
+
+/**
+ * All 401'ed requests belonging to this base URL will trigger a redirect to the shop owner login page.
+ */
+const API_SHOP_OWNER_BASE = '/api/shop';
+
+/**
+ * These URLs will NOT trigger a redirect to the shop owner login page.
+ */
+const API_SHOP_OWNER_WHITELIST = [
+  '/api/shop/login'
+];
+
+@Injectable()
+export class LogoutInterceptor implements HttpInterceptor {
+
+  constructor(
+    private router: Router,
+    private adminService: AdminService,
+    private shopOwnerService: ShopOwnerService
+  ) {
+  }
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    return next.handle(request).pipe(
+      catchError((error: HttpErrorResponse) => {
+        if (error?.status === 401) {
+          // some "unauthorized" call, alright
+          const {url} = request;
+
+          if (this.wasAdminRequest(url)) {
+            // redirect to admin login page
+            this.adminService.forceLogoutState();
+            this.router.navigate(['/admin']);
+
+          } else if (this.wasShopOwnerRequest(url)) {
+            // redirect to shop owner login page
+            this.shopOwnerService.forceLogoutState();
+            this.router.navigate(['/login']);
+          }
+        }
+
+        return throwError(error);
+      })
+    );
+  }
+
+  private wasAdminRequest(url: string): boolean {
+    return url.startsWith(API_ADMIN_BASE) && !API_ADMIN_WHITELIST.some(wl => wl === url);
+  }
+
+  private wasShopOwnerRequest(url: string): boolean {
+    return url.startsWith(API_SHOP_OWNER_BASE) && !API_SHOP_OWNER_WHITELIST.some(wl => wl === url);
+  }
+
+}

--- a/frontend/src/app/data/logout.interceptor.ts
+++ b/frontend/src/app/data/logout.interceptor.ts
@@ -1,10 +1,10 @@
 import {Injectable} from '@angular/core';
 import {HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
-import {Observable, throwError} from 'rxjs';
+import {NEVER, Observable, throwError} from 'rxjs';
 import {catchError} from 'rxjs/operators';
 import {Router} from '@angular/router';
-import {AdminService} from '../shared/admin.service';
-import {ShopOwnerService} from '../shared/shop-owner.service';
+import {LoginStateService} from '../shared/login-state.service';
+import {NotificationsService} from 'angular2-notifications';
 
 /**
  * All 401'ed requests belonging to this base URL will trigger a redirect to the admin login page.
@@ -12,31 +12,30 @@ import {ShopOwnerService} from '../shared/shop-owner.service';
 const API_ADMIN_BASE = '/api/admin';
 
 /**
- * These URLs will NOT trigger a redirect to the admin login page.
+ * Admin "whoami" call (ignored because we're doing it during the app startup already).
  */
-const API_ADMIN_WHITELIST = [
-  '/api/admin/login'
-];
+const API_ADMIN_WHOAMI = '/api/admin/login';
 
 /**
- * All 401'ed requests belonging to this base URL will trigger a redirect to the shop owner login page.
+ * Shop owner "whoami" call (ignored because we're doing it during the app startup already).
  */
-const API_SHOP_OWNER_BASE = '/api/shop';
-
-/**
- * These URLs will NOT trigger a redirect to the shop owner login page.
- */
-const API_SHOP_OWNER_WHITELIST = [
-  '/api/shop/login'
-];
+const API_SHOP_WHOAMI = '/api/shop/login';
 
 @Injectable()
 export class LogoutInterceptor implements HttpInterceptor {
 
+  private static wasWhoamiRequest({url, method}: HttpRequest<unknown>): boolean {
+    return method === 'GET' && (url.startsWith(API_ADMIN_WHOAMI) || url.startsWith(API_SHOP_WHOAMI));
+  }
+
+  private static wasAdminRequest(url: string): boolean {
+    return url.startsWith(API_ADMIN_BASE);
+  }
+
   constructor(
     private router: Router,
-    private adminService: AdminService,
-    private shopOwnerService: ShopOwnerService
+    private loginStateService: LoginStateService,
+    private notificationsService: NotificationsService
   ) {
   }
 
@@ -47,29 +46,39 @@ export class LogoutInterceptor implements HttpInterceptor {
           // some "unauthorized" call, alright
           const {url} = request;
 
-          if (this.wasAdminRequest(url)) {
-            // redirect to admin login page
-            this.adminService.forceLogoutState();
-            this.router.navigate(['/admin']);
+          if (LogoutInterceptor.wasWhoamiRequest(request)) {
+            // simply ignore the failed whoami requests
 
-          } else if (this.wasShopOwnerRequest(url)) {
+          } else if (LogoutInterceptor.wasAdminRequest(url)) {
+            this.notificationsService.alert(
+              'Ausgeloggt',
+              'Ihre Login-Session ist vermutlich abgelaufen. Bitte loggen Sie sich noch einmal ein.'
+            );
+
+            this.loginStateService.logoutAdmin();
+
+            // redirect to admin login page
+            this.router.navigateByUrl('/admin');
+
+          } else {
+            this.notificationsService.alert(
+              'Ausgeloggt',
+              'Ihre Login-Session ist vermutlich abgelaufen. Bitte loggen Sie sich noch einmal ein.'
+            );
+
+            this.loginStateService.logoutShopOwner();
+
             // redirect to shop owner login page
-            this.shopOwnerService.forceLogoutState();
-            this.router.navigate(['/login']);
+            this.router.navigateByUrl('/login');
           }
+
+          // don't want to re-throw an error which might cause error messages to pop up
+          return NEVER;
         }
 
         return throwError(error);
       })
     );
-  }
-
-  private wasAdminRequest(url: string): boolean {
-    return url.startsWith(API_ADMIN_BASE) && !API_ADMIN_WHITELIST.some(wl => wl === url);
-  }
-
-  private wasShopOwnerRequest(url: string): boolean {
-    return url.startsWith(API_SHOP_OWNER_BASE) && !API_SHOP_OWNER_WHITELIST.some(wl => wl === url);
   }
 
 }

--- a/frontend/src/app/shared/admin.service.ts
+++ b/frontend/src/app/shared/admin.service.ts
@@ -4,8 +4,9 @@ import {ShopAdminDto, ShopsAdminDto, TokenInfoDto} from '../data/api';
 import {UpdateShopData} from '../shop-details-config/shop-details-config.component';
 import {Observable, Subject} from 'rxjs';
 
-const API_ADMIN_TOKEN_INFO = '/api/admin/login/token-info';
-const API_ADMIN_LOGIN = '/api/admin/login';
+const API_ADMIN = '/api/admin';
+const API_ADMIN_LOGIN = `${API_ADMIN}/login`;
+const API_ADMIN_TOKEN_INFO = `${API_ADMIN}/login/token-info`;
 
 @Injectable({providedIn: 'root'})
 export class AdminService {
@@ -33,6 +34,10 @@ export class AdminService {
     this.loggedIn.next(true);
   }
 
+  forceLogoutState() {
+    this.loggedIn.next(false);
+  }
+
   logout(): Promise<void> {
     return this.client.delete(API_ADMIN_LOGIN).toPromise()
       .then(() => console.log('Admin logout successful.'))
@@ -41,31 +46,31 @@ export class AdminService {
   }
 
   listAllShops(): Promise<ShopsAdminDto> {
-    return this.client.get('/api/admin/shop').toPromise();
+    return this.client.get(`${API_ADMIN}/shop`).toPromise();
   }
 
   getShopWithId(id: string): Promise<ShopAdminDto> {
     const shopId = encodeURIComponent(id);
 
-    return this.client.get<ShopAdminDto>(`/api/admin/shop/${shopId}`).toPromise();
+    return this.client.get<ShopAdminDto>(`${API_ADMIN}/shop/${shopId}`).toPromise();
   }
 
   updateShop(updatedShop: UpdateShopData) {
     const shopId = encodeURIComponent(updatedShop.id);
 
-    return this.client.put(`/api/admin/shop/${shopId}`, updatedShop.updateShopDto).toPromise();
+    return this.client.put(`${API_ADMIN}/shop/${shopId}`, updatedShop.updateShopDto).toPromise();
   }
 
   deleteShop(id: string) {
     const shopId = encodeURIComponent(id);
 
-    return this.client.delete(`/api/admin/shop/${shopId}`).toPromise();
+    return this.client.delete(`${API_ADMIN}/shop/${shopId}`).toPromise();
   }
 
   changeShopApproval(id: string, enabled: boolean) {
     const shopId = encodeURIComponent(id);
 
-    return this.client.put(`/api/admin/shop/${shopId}/approve?approved=${enabled}`, {}).toPromise();
+    return this.client.put(`${API_ADMIN}/shop/${shopId}/approve?approved=${enabled}`, {}).toPromise();
   }
 
 }

--- a/frontend/src/app/shared/login-state.service.ts
+++ b/frontend/src/app/shared/login-state.service.ts
@@ -1,0 +1,51 @@
+import {Injectable} from '@angular/core';
+import {Observable, Subject} from 'rxjs';
+
+/**
+ * Holds the frontend app's assumption about whether the user is logged in as admin or shopowner or not at all.
+ *
+ * IMPORTANT: This only exists because we have to "write" to this from the {@link LogoutInterceptor} which can't rely
+ * on stuff that itself relies on a {@link HttpClient}.
+ *
+ * => DO NOT INJECT AND USE THIS IN THE APP. NOWHERE.
+ *
+ * Only the {@link AdminService}, the {@link ShopOwnerService} and the aforementioned {@link LogoutInterceptor} shall
+ * use this, period.
+ */
+@Injectable({providedIn: 'root'})
+export class LoginStateService {
+
+  private adminSubject = new Subject<boolean>();
+  private shopOwnerSubject = new Subject<boolean>();
+
+  constructor() {
+    this.adminSubject.next(false);
+    this.shopOwnerSubject.next(false);
+  }
+
+  get isAdmin(): Observable<boolean> {
+    return this.adminSubject.asObservable();
+  }
+
+  loginAdmin() {
+    this.adminSubject.next(true);
+    this.shopOwnerSubject.next(false);
+  }
+
+  logoutAdmin() {
+    this.adminSubject.next(false);
+  }
+
+  get isShopOwner(): Observable<boolean> {
+    return this.shopOwnerSubject.asObservable();
+  }
+
+  loginShopOwner() {
+    this.shopOwnerSubject.next(true);
+  }
+
+  logoutShopOwner() {
+    this.shopOwnerSubject.next(false);
+  }
+
+}

--- a/frontend/src/app/shared/shop-owner.service.ts
+++ b/frontend/src/app/shared/shop-owner.service.ts
@@ -54,6 +54,10 @@ export class ShopOwnerService {
       });
   }
 
+  forceLogoutState() {
+    this.loggedIn.next(false);
+  }
+
   logout() {
     return this.http.delete('/api/shop/login').toPromise()
 

--- a/frontend/src/app/shared/shop-owner.service.ts
+++ b/frontend/src/app/shared/shop-owner.service.ts
@@ -1,6 +1,7 @@
 import {Injectable} from '@angular/core';
-import {Observable, Subject} from 'rxjs';
+import {Observable} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
+import {LoginStateService} from './login-state.service';
 import {TokenInfoDto} from '../data/api';
 
 export interface LoginCredentials {
@@ -22,24 +23,22 @@ const API_SHOP_OWNER_PASSWORD_RESET = '/api/shop/send-password-reset-link';
 @Injectable({providedIn: 'root'})
 export class ShopOwnerService {
 
-  private loggedIn = new Subject<boolean>();
-
-  constructor(private http: HttpClient) {
+  constructor(private http: HttpClient, private loginStateService: LoginStateService) {
     // call token-info to determine the initial state on page load
     this.http.get(API_SHOP_OWNER_TOKEN_INFO).toPromise()
       .then((response: TokenInfoDto) => {
         if (response.status === 'LOGGED_IN') {
-          this.loggedIn.next(true);
+          this.loginStateService.loginShopOwner();
 
         } else {
-          this.loggedIn.next(false);
+          this.loginStateService.logoutShopOwner();
         }
       })
-      .catch(() => this.loggedIn.next(false));
+      .catch(() => this.loginStateService.logoutShopOwner());
   }
 
   get shopOwnerLoggedIn(): Observable<boolean> {
-    return this.loggedIn.asObservable();
+    return this.loginStateService.isShopOwner;
   }
 
   login(credentials: LoginCredentials) {
@@ -49,13 +48,9 @@ export class ShopOwnerService {
 
       .catch(error => {
         console.error('[ShopOwnerService] Login failed.', error);
-        this.loggedIn.next(false);
+        this.loginStateService.logoutShopOwner();
         throw error;
       });
-  }
-
-  forceLogoutState() {
-    this.loggedIn.next(false);
   }
 
   logout() {
@@ -68,7 +63,7 @@ export class ShopOwnerService {
         throw error;
       })
 
-      .finally(() => this.loggedIn.next(false));
+      .finally(() => this.loginStateService.logoutShopOwner());
   }
 
   resetPassword(body: ResetPasswordBody) {
@@ -85,12 +80,12 @@ export class ShopOwnerService {
 
   /** @deprecated */
   storeOwnerLoggedIn(): void {
-    this.loggedIn.next(true);
+    this.loginStateService.loginShopOwner();
   }
 
   /** @deprecated */
   storeOwnerLoggedOut(): void {
-    this.loggedIn.next(false);
+    this.loginStateService.logoutShopOwner();
   }
 
 }


### PR DESCRIPTION
This will detect 401 responses on all returning HttpClient requests and redirects the user accordingly.

Admins will see the login page for admins, shop owners the regular login page. The original "login" API calls, however, are not triggering this redirect (because we're doing these requests at the very startup of the app to determine whether we're having a session right now or not)

Closes #236 