### PR TITLE
Feature/59 email ics

### DIFF
--- a/backend/src/main/java/de/qaware/mercury/business/email/Attachment.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/Attachment.java
@@ -1,0 +1,13 @@
+package de.qaware.mercury.business.email;
+
+import lombok.Value;
+
+/**
+ * An email attachment.
+ */
+@Value
+public class Attachment {
+    String filename;
+    String contentType;
+    byte[] content;
+}

--- a/backend/src/main/java/de/qaware/mercury/business/email/EmailSender.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/EmailSender.java
@@ -3,7 +3,7 @@ package de.qaware.mercury.business.email;
 import java.util.List;
 
 public interface EmailSender {
-    void sendEmail(String recipient, String subject, String body);
+    void sendEmail(String recipient, String subject, String body, Attachment... attachments);
 
-    void sendEmails(List<String> recipients, String subject, String body);
+    void sendEmails(List<String> recipients, String subject, String body, Attachment... attachments);
 }

--- a/backend/src/main/java/de/qaware/mercury/business/email/ICalendarService.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/ICalendarService.java
@@ -4,6 +4,19 @@ import de.qaware.mercury.business.reservation.Reservation;
 
 import java.time.LocalDateTime;
 
+/**
+ * Creates iCalendar files.
+ */
 public interface ICalendarService {
-    String createICalendar(Reservation.Id reservationId, LocalDateTime start, LocalDateTime end, String summary, String description);
+    /**
+     * Creates an iCalendar file for a new reservation.
+     *
+     * @param reservationId id of the reservation
+     * @param start         start of the reservation
+     * @param end           end of the reservation
+     * @param summary       iCalendar summary
+     * @param description   iCalendar description
+     * @return Content of the iCalendar file.
+     */
+    String newReservation(Reservation.Id reservationId, LocalDateTime start, LocalDateTime end, String summary, String description);
 }

--- a/backend/src/main/java/de/qaware/mercury/business/email/ICalendarService.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/ICalendarService.java
@@ -2,6 +2,8 @@ package de.qaware.mercury.business.email;
 
 import de.qaware.mercury.business.reservation.Reservation;
 
+import java.time.LocalDateTime;
+
 public interface ICalendarService {
-    String createICalendar(Reservation reservation, String summary, String description);
+    String createICalendar(Reservation.Id reservationId, LocalDateTime start, LocalDateTime end, String summary, String description);
 }

--- a/backend/src/main/java/de/qaware/mercury/business/email/ICalendarService.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/ICalendarService.java
@@ -1,0 +1,7 @@
+package de.qaware.mercury.business.email;
+
+import de.qaware.mercury.business.reservation.Reservation;
+
+public interface ICalendarService {
+    String createICalendar(Reservation reservation, String summary, String description);
+}

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/DummyEmailSender.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/DummyEmailSender.java
@@ -1,5 +1,6 @@
 package de.qaware.mercury.business.email.impl;
 
+import de.qaware.mercury.business.email.Attachment;
 import de.qaware.mercury.business.email.EmailSender;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -13,12 +14,12 @@ import java.util.List;
 @Slf4j
 class DummyEmailSender implements EmailSender {
     @Override
-    public void sendEmail(String recipient, String subject, String body) {
+    public void sendEmail(String recipient, String subject, String body, Attachment... attachments) {
         sendEmails(Collections.singletonList(recipient), subject, body);
     }
 
     @Override
-    public void sendEmails(List<String> recipients, String subject, String body) {
+    public void sendEmails(List<String> recipients, String subject, String body, Attachment... attachments) {
         log.info("----------------------");
         log.info("Sending email(s) to {}", recipients);
         log.info("{}", subject);

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/EmailSenderImpl.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/EmailSenderImpl.java
@@ -1,17 +1,19 @@
 package de.qaware.mercury.business.email.impl;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import de.qaware.mercury.business.email.Attachment;
 import de.qaware.mercury.business.email.EmailSender;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.mail.MailSender;
-import org.springframework.mail.SimpleMailMessage;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -25,10 +27,10 @@ import java.util.concurrent.TimeUnit;
 @ConditionalOnProperty(name = "mercury.email.use-dummy", havingValue = "false")
 class EmailSenderImpl implements EmailSender {
     private final EmailConfigurationProperties config;
-    private final MailSender mailSender;
+    private final JavaMailSender mailSender;
     private ExecutorService executor;
 
-    EmailSenderImpl(EmailConfigurationProperties config, MailSender mailSender) {
+    EmailSenderImpl(EmailConfigurationProperties config, JavaMailSender mailSender) {
         this.config = config;
         this.mailSender = mailSender;
     }
@@ -60,39 +62,39 @@ class EmailSenderImpl implements EmailSender {
     }
 
     @Override
-    public void sendEmail(String recipient, String subject, String body) {
-        sendEmails(Collections.singletonList(recipient), subject, body);
+    public void sendEmail(String recipient, String subject, String body, Attachment... attachments) {
+        sendEmails(Collections.singletonList(recipient), subject, body, attachments);
     }
 
     @Override
-    public void sendEmails(List<String> recipients, String subject, String body) {
-        String[] recipientArray = recipients.toArray(new String[0]);
-
-        SimpleMailMessage mail = new SimpleMailMessage();
-        mail.setFrom(config.getFrom());
-        mail.setTo(recipientArray);
-        mail.setSubject(subject);
-        mail.setText(body);
-
+    public void sendEmails(List<String> recipients, String subject, String body, Attachment... attachments) {
         // Send email async
-        executor.submit(() -> sendMailSafe(mail, recipientArray));
+        executor.submit(() -> sendMailSafe(recipients, subject, body, attachments));
     }
 
     /**
      * Sends an email without throwing exceptions
      *
-     * @param mail       mail to send
      * @param recipients recipient of the mail
+     * @param subject    subject of the mail
+     * @param body       body of the mail
      */
-    private void sendMailSafe(SimpleMailMessage mail, String... recipients) {
-        String recipientsAsString = Arrays.toString(recipients);
-
-        log.debug("Sending mail to '{}'", recipientsAsString);
+    private void sendMailSafe(List<String> recipients, String subject, String body, Attachment... attachments) {
+        log.debug("Sending mail to '{}'", recipients);
         try {
-            mailSender.send(mail);
-            log.debug("Sent mail to '{}'", recipientsAsString);
+            mailSender.send(mimeMessage -> {
+                MimeMessageHelper mail = new MimeMessageHelper(mimeMessage, true, StandardCharsets.UTF_8.toString());
+                mail.setFrom(config.getFrom());
+                mail.setTo(recipients.toArray(new String[0]));
+                mail.setSubject(subject);
+                mail.setText(body);
+                for (Attachment attachment : attachments) {
+                    mail.addAttachment(attachment.getFilename(), new ByteArrayResource(attachment.getContent()), attachment.getContentType());
+                }
+            });
+            log.debug("Sent mail to '{}'", recipients);
         } catch (Exception e) {
-            log.error("Failed to send email to '{}', subject '{}'", recipientsAsString, mail.getSubject(), e);
+            log.error("Failed to send email to '{}', subject '{}'", recipients, subject, e);
         }
     }
 }

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/EmailServiceImpl.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/EmailServiceImpl.java
@@ -105,7 +105,7 @@ class EmailServiceImpl implements EmailService {
             .replace(EmailTemplateConstants.CONTACT, contact)
             .replace(EmailTemplateConstants.CANCEL_RESERVATION_LINK, cancelReservationLink);
 
-        String ics = iCalendarService.createICalendar(reservationId, slotStart, slotEnd, subject, body);
+        String ics = iCalendarService.newReservation(reservationId, slotStart, slotEnd, subject, body);
         Attachment attachment = new Attachment("Reservierung.ics", "text/calendar", ics.getBytes(StandardCharsets.UTF_8));
 
         emailSender.sendEmail(shop.getEmail(), subject, body, attachment);

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/EmailServiceImpl.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/EmailServiceImpl.java
@@ -1,8 +1,10 @@
 package de.qaware.mercury.business.email.impl;
 
 import de.qaware.mercury.business.admin.Admin;
+import de.qaware.mercury.business.email.Attachment;
 import de.qaware.mercury.business.email.EmailSender;
 import de.qaware.mercury.business.email.EmailService;
+import de.qaware.mercury.business.email.ICalendarService;
 import de.qaware.mercury.business.email.SendEmailException;
 import de.qaware.mercury.business.i18n.DateTimeI18nService;
 import de.qaware.mercury.business.login.PasswordResetToken;
@@ -52,6 +54,7 @@ class EmailServiceImpl implements EmailService {
     private final TokenService tokenService;
     private final DateTimeI18nService dateTimeI18nService;
     private final MessageSource messageSource;
+    private final ICalendarService iCalendarService;
 
     @Override
     public void sendShopCreationLink(String email) {
@@ -91,6 +94,7 @@ class EmailServiceImpl implements EmailService {
         String cancelReservationLink = config.getReservationCancellationLinkTemplate()
             .replace(EmailTemplateConstants.TOKEN, token.getToken());
 
+        String subject = getTranslation(SHOP_NEW_RESERVATION_SUBJECT);
         String body = loadTemplate("/email/shop-new-reservation.txt")
             .replace(EmailTemplateConstants.CUSTOMER_NAME, customerName)
             .replace(EmailTemplateConstants.OWNER_NAME, shop.getOwnerName())
@@ -101,7 +105,10 @@ class EmailServiceImpl implements EmailService {
             .replace(EmailTemplateConstants.CONTACT, contact)
             .replace(EmailTemplateConstants.CANCEL_RESERVATION_LINK, cancelReservationLink);
 
-        emailSender.sendEmail(shop.getEmail(), getTranslation(SHOP_NEW_RESERVATION_SUBJECT), body);
+        String ics = iCalendarService.createICalendar(reservationId, slotStart, slotEnd, subject, body);
+        Attachment attachment = new Attachment("Reservierung.ics", "text/calendar", ics.getBytes(StandardCharsets.UTF_8));
+
+        emailSender.sendEmail(shop.getEmail(), subject, body, attachment);
     }
 
     @Override

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarConfigurationProperties.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarConfigurationProperties.java
@@ -1,0 +1,17 @@
+package de.qaware.mercury.business.email.impl;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import javax.validation.constraints.NotBlank;
+
+@Data
+@ConfigurationProperties("mercury.ical")
+@Validated
+class ICalendarConfigurationProperties {
+    @NotBlank
+    private String organizerName;
+    @NotBlank
+    private String organizerEmail;
+}

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarServiceImpl.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarServiceImpl.java
@@ -25,7 +25,7 @@ class ICalendarServiceImpl implements ICalendarService {
     private final ICalendarConfigurationProperties configuration;
 
     @Override
-    public String createICalendar(Reservation.Id reservationId, LocalDateTime start, LocalDateTime end, String summary, String description) {
+    public String newReservation(Reservation.Id reservationId, LocalDateTime start, LocalDateTime end, String summary, String description) {
         return "BEGIN:VCALENDAR" + NEWLINE +
             "VERSION:2.0" + NEWLINE +
             "PRODID:-//lokaler.kaufen/lokaler.kaufen//EN" + NEWLINE +

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarServiceImpl.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarServiceImpl.java
@@ -5,6 +5,7 @@ import de.qaware.mercury.business.reservation.Reservation;
 import de.qaware.mercury.business.time.Clock;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -14,12 +15,14 @@ import java.time.format.DateTimeFormatter;
 
 @Service
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+@EnableConfigurationProperties(ICalendarConfigurationProperties.class)
 class ICalendarServiceImpl implements ICalendarService {
     private static final String NEWLINE = "\r\n"; // Must be \r\n to adhere the standard
     private static final DateTimeFormatter UTC = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"); // 19970714T170000Z
     private static final DateTimeFormatter LOCAL = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"); // 19970714T170000
 
     private final Clock clock;
+    private final ICalendarConfigurationProperties configuration;
 
     @Override
     public String createICalendar(Reservation.Id reservationId, LocalDateTime start, LocalDateTime end, String summary, String description) {
@@ -28,6 +31,7 @@ class ICalendarServiceImpl implements ICalendarService {
             "PRODID:-//lokaler.kaufen/lokaler.kaufen//EN" + NEWLINE +
             "BEGIN:VEVENT" + NEWLINE +
             "UID:" + reservationId.getId() + NEWLINE +
+            "ORGANIZER;CN=" + configuration.getOrganizerName() + ":MAILTO:" + configuration.getOrganizerEmail() + NEWLINE +
             "DTSTAMP:" + formatDateUTC(clock.nowZoned()) + NEWLINE +
             "DTSTART:" + formatDateLocal(start) + NEWLINE +
             "DTEND:" + formatDateLocal(end) + NEWLINE +

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarServiceImpl.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarServiceImpl.java
@@ -22,16 +22,15 @@ class ICalendarServiceImpl implements ICalendarService {
     private final Clock clock;
 
     @Override
-    public String createICalendar(Reservation reservation, String summary, String description) {
+    public String createICalendar(Reservation.Id reservationId, LocalDateTime start, LocalDateTime end, String summary, String description) {
         return "BEGIN:VCALENDAR" + NEWLINE +
             "VERSION:2.0" + NEWLINE +
             "PRODID:-//lokaler.kaufen/lokaler.kaufen//EN" + NEWLINE +
             "BEGIN:VEVENT" + NEWLINE +
-            "UID:" + reservation.getId().getId() + NEWLINE +
-            "ORGANIZER;CN=lokaler.kaufen:MAILTO:info@lokaler.kaufen" + NEWLINE + // TODO: Replace with properties
+            "UID:" + reservationId.getId() + NEWLINE +
             "DTSTAMP:" + formatDateUTC(clock.nowZoned()) + NEWLINE +
-            "DTSTART:" + formatDateLocal(reservation.getStart()) + NEWLINE +
-            "DTEND:" + formatDateLocal(reservation.getStart()) + NEWLINE +
+            "DTSTART:" + formatDateLocal(start) + NEWLINE +
+            "DTEND:" + formatDateLocal(end) + NEWLINE +
             "SUMMARY:" + escapeText(summary) + NEWLINE +
             "DESCRIPTION:" + escapeText(description) + NEWLINE +
             "END:VEVENT" + NEWLINE +

--- a/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarServiceImpl.java
+++ b/backend/src/main/java/de/qaware/mercury/business/email/impl/ICalendarServiceImpl.java
@@ -1,0 +1,61 @@
+package de.qaware.mercury.business.email.impl;
+
+import de.qaware.mercury.business.email.ICalendarService;
+import de.qaware.mercury.business.reservation.Reservation;
+import de.qaware.mercury.business.time.Clock;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+class ICalendarServiceImpl implements ICalendarService {
+    private static final String NEWLINE = "\r\n"; // Must be \r\n to adhere the standard
+    private static final DateTimeFormatter UTC = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"); // 19970714T170000Z
+    private static final DateTimeFormatter LOCAL = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"); // 19970714T170000
+
+    private final Clock clock;
+
+    @Override
+    public String createICalendar(Reservation reservation, String summary, String description) {
+        return "BEGIN:VCALENDAR" + NEWLINE +
+            "VERSION:2.0" + NEWLINE +
+            "PRODID:-//lokaler.kaufen/lokaler.kaufen//EN" + NEWLINE +
+            "BEGIN:VEVENT" + NEWLINE +
+            "UID:" + reservation.getId().getId() + NEWLINE +
+            "ORGANIZER;CN=lokaler.kaufen:MAILTO:info@lokaler.kaufen" + NEWLINE + // TODO: Replace with properties
+            "DTSTAMP:" + formatDateUTC(clock.nowZoned()) + NEWLINE +
+            "DTSTART:" + formatDateLocal(reservation.getStart()) + NEWLINE +
+            "DTEND:" + formatDateLocal(reservation.getStart()) + NEWLINE +
+            "SUMMARY:" + escapeText(summary) + NEWLINE +
+            "DESCRIPTION:" + escapeText(description) + NEWLINE +
+            "END:VEVENT" + NEWLINE +
+            "END:VCALENDAR" + NEWLINE;
+    }
+
+    // See https://www.kanzaki.com/docs/ical/dateTime.html
+    private String formatDateLocal(LocalDateTime dateTime) {
+        return dateTime.format(LOCAL);
+    }
+
+    // See https://www.kanzaki.com/docs/ical/dateTime.html
+    private String formatDateUTC(ZonedDateTime dateTime) {
+        return dateTime.withZoneSameInstant(ZoneOffset.UTC).format(UTC);
+    }
+
+    // See https://www.kanzaki.com/docs/ical/text.html
+    private String escapeText(String text) {
+        return text
+            .replace("\\", "\\\\") // \ -> \\
+            .replace("\r\n", "\\n") // newline -> \n
+            .replace("\r", "\\n") // newline -> \n
+            .replace("\n", "\\n") // newline -> \n
+            .replace(";", "\\;") // ; -> \;
+            .replace(",", "\\,"); // ; -> \;
+    }
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -31,6 +31,9 @@ mercury:
     secure: true
   tokens:
     masterKey: "fZZP2re13vX7Q6xEWJDlAyYdzwtmZTmSEvjafucWlYg=" # Must be Base64, generated with openssl rand -base64 32
+  ical:
+    organizer-email: "noreply@lokaler.kaufen"
+    organizer-name: "Lokaler.kaufen"
   email:
     useDummy: true # Set this to false to send real emails
     from: "Lokaler.kaufen <info@lokaler.kaufen>"

--- a/backend/src/test/groovy/de/qaware/mercury/business/email/impl/EmailSenderImplSpec.groovy
+++ b/backend/src/test/groovy/de/qaware/mercury/business/email/impl/EmailSenderImplSpec.groovy
@@ -1,17 +1,20 @@
 package de.qaware.mercury.business.email.impl
 
-import org.springframework.mail.MailSender
+
+import org.springframework.mail.javamail.JavaMailSender
 import spock.lang.Specification
+import spock.lang.Subject
 
 class EmailSenderImplSpec extends Specification {
 
-    EmailConfigurationProperties properties
-    MailSender mailSender
+    EmailConfigurationProperties properties = new EmailConfigurationProperties()
+    JavaMailSender mailSender = Mock()
+    @Subject
     EmailSenderImpl emailSender
 
     void setup() {
-        properties = Mock(EmailConfigurationProperties)
-        mailSender = Mock(MailSender)
+        properties.setFrom("test@local.host")
+
         emailSender = new EmailSenderImpl(properties, mailSender)
         emailSender.init()
     }
@@ -25,8 +28,6 @@ class EmailSenderImplSpec extends Specification {
         emailSender.sendEmail('mlr@qaware.de', 'Spock Tests', 'Rocks!')
 
         then:
-        1 * properties.from >> 'test@lokaler.kaufen'
         noExceptionThrown()
-        // 1 * mailSender.send(_)
     }
 }

--- a/backend/src/test/groovy/de/qaware/mercury/business/email/impl/EmailServiceImplSpec.groovy
+++ b/backend/src/test/groovy/de/qaware/mercury/business/email/impl/EmailServiceImplSpec.groovy
@@ -78,7 +78,7 @@ class EmailServiceImplSpec extends Specification {
         Shop shop = Shop.builder().ownerName('Spock').build()
         LocalDateTime slot = LocalDateTime.now()
         Reservation.Id reservationId = Reservation.Id.of(UUID.randomUUID())
-        iCalendarService.createICalendar(reservationId, slot, slot, _, _) >> ""
+        iCalendarService.newReservation(reservationId, slot, slot, _, _) >> ""
 
         when:
         emailService.sendShopNewReservation(shop, 'Test Shop', slot, slot, ContactType.WHATSAPP, 'Spock', reservationId)

--- a/backend/src/test/groovy/de/qaware/mercury/business/email/impl/EmailServiceImplSpec.groovy
+++ b/backend/src/test/groovy/de/qaware/mercury/business/email/impl/EmailServiceImplSpec.groovy
@@ -1,6 +1,7 @@
 package de.qaware.mercury.business.email.impl
 
 import de.qaware.mercury.business.email.EmailSender
+import de.qaware.mercury.business.email.ICalendarService
 import de.qaware.mercury.business.i18n.DateTimeI18nService
 import de.qaware.mercury.business.login.PasswordResetToken
 import de.qaware.mercury.business.login.ReservationCancellationToken
@@ -19,20 +20,15 @@ class EmailServiceImplSpec extends Specification {
     static final String EMAIL = 'test@lokaler.kaufen'
 
     EmailServiceImpl emailService
-    EmailSender emailSender
-    EmailConfigurationProperties properties
-    TokenService tokenService
-    DateTimeI18nService i18nService
-    MessageSource messageSource
+    EmailSender emailSender = Mock()
+    EmailConfigurationProperties properties = Mock()
+    TokenService tokenService = Mock()
+    DateTimeI18nService i18nService = Mock()
+    MessageSource messageSource = Mock()
+    ICalendarService iCalendarService = Mock()
 
     void setup() {
-        emailSender = Mock(EmailSender)
-        properties = Mock(EmailConfigurationProperties)
-        tokenService = Mock(TokenService)
-        i18nService = Mock(DateTimeI18nService)
-        messageSource = Mock(MessageSource)
-
-        emailService = new EmailServiceImpl(emailSender, properties, tokenService, i18nService, messageSource)
+        emailService = new EmailServiceImpl(emailSender, properties, tokenService, i18nService, messageSource, iCalendarService)
     }
 
     def "Send Shop creation link"() {
@@ -82,6 +78,7 @@ class EmailServiceImplSpec extends Specification {
         Shop shop = Shop.builder().ownerName('Spock').build()
         LocalDateTime slot = LocalDateTime.now()
         Reservation.Id reservationId = Reservation.Id.of(UUID.randomUUID())
+        iCalendarService.createICalendar(reservationId, slot, slot, _, _) >> ""
 
         when:
         emailService.sendShopNewReservation(shop, 'Test Shop', slot, slot, ContactType.WHATSAPP, 'Spock', reservationId)

--- a/backend/src/test/groovy/de/qaware/mercury/business/email/impl/ICalendarServiceImplTest.groovy
+++ b/backend/src/test/groovy/de/qaware/mercury/business/email/impl/ICalendarServiceImplTest.groovy
@@ -1,0 +1,38 @@
+package de.qaware.mercury.business.email.impl
+
+import de.qaware.mercury.business.email.ICalendarService
+import de.qaware.mercury.business.reservation.Reservation
+import de.qaware.mercury.test.time.TestClock
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.nio.charset.StandardCharsets
+import java.time.LocalDateTime
+
+class ICalendarServiceImplTest extends Specification {
+    @Subject
+    ICalendarService sut
+    TestClock testClock = TestClock.fixed()
+
+    def setup() {
+        ICalendarConfigurationProperties configuration = new ICalendarConfigurationProperties()
+        configuration.setOrganizerEmail("organizer@local.host")
+        configuration.setOrganizerName("The organizer")
+
+        sut = new ICalendarServiceImpl(testClock, configuration)
+    }
+
+    def "create"() {
+        given:
+        Reservation.Id reservationId = Reservation.Id.of(UUID.fromString("830d9f5c-28c4-4bdf-b5d2-22f57c49bd64"))
+        LocalDateTime start = LocalDateTime.of(2020, 4, 26, 17, 0)
+        LocalDateTime end = LocalDateTime.of(2020, 4, 26, 19, 0)
+
+        when:
+        String ics = sut.createICalendar(reservationId, start, end, "This is the summary", "This is the description\nAnd it contains a new line\r\nand several chars: , ; \\")
+
+        then:
+        // Compare ignoring the line endings
+        ics.readLines() == ICalendarServiceImplTest.getResourceAsStream("/icalendar/1.ics").readLines(StandardCharsets.UTF_8.toString())
+    }
+}

--- a/backend/src/test/groovy/de/qaware/mercury/business/email/impl/ICalendarServiceImplTest.groovy
+++ b/backend/src/test/groovy/de/qaware/mercury/business/email/impl/ICalendarServiceImplTest.groovy
@@ -29,7 +29,7 @@ class ICalendarServiceImplTest extends Specification {
         LocalDateTime end = LocalDateTime.of(2020, 4, 26, 19, 0)
 
         when:
-        String ics = sut.createICalendar(reservationId, start, end, "This is the summary", "This is the description\nAnd it contains a new line\r\nand several chars: , ; \\")
+        String ics = sut.newReservation(reservationId, start, end, "This is the summary", "This is the description\nAnd it contains a new line\r\nand several chars: , ; \\")
 
         then:
         // Compare ignoring the line endings

--- a/backend/src/test/java/de/qaware/mercury/test/email/Email.java
+++ b/backend/src/test/java/de/qaware/mercury/test/email/Email.java
@@ -1,7 +1,9 @@
 package de.qaware.mercury.test.email;
 
+import de.qaware.mercury.business.email.Attachment;
 import lombok.Value;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -14,6 +16,7 @@ public class Email {
     Set<String> recipients;
     String subject;
     String body;
+    List<Attachment> attachments;
 
     /**
      * Searches for a token in the body.

--- a/backend/src/test/java/de/qaware/mercury/test/email/Emails.java
+++ b/backend/src/test/java/de/qaware/mercury/test/email/Emails.java
@@ -1,8 +1,10 @@
 package de.qaware.mercury.test.email;
 
+import de.qaware.mercury.business.email.Attachment;
 import lombok.Getter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -11,12 +13,12 @@ public class Emails {
     @Getter
     private final List<Email> emails = new ArrayList<>();
 
-    public void add(String recipient, String subject, String body) {
-        add(Set.of(recipient), subject, body);
+    public void add(String recipient, String subject, String body, Attachment... attachments) {
+        add(Set.of(recipient), subject, body, attachments);
     }
 
-    public void add(Set<String> recipients, String subject, String body) {
-        add(new Email(recipients, subject, body));
+    public void add(Set<String> recipients, String subject, String body, Attachment... attachments) {
+        add(new Email(recipients, subject, body, Arrays.asList(attachments)));
     }
 
     public void add(Email email) {

--- a/backend/src/test/java/de/qaware/mercury/test/email/TestEmailSender.java
+++ b/backend/src/test/java/de/qaware/mercury/test/email/TestEmailSender.java
@@ -1,5 +1,6 @@
 package de.qaware.mercury.test.email;
 
+import de.qaware.mercury.business.email.Attachment;
 import de.qaware.mercury.business.email.EmailSender;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -13,14 +14,14 @@ public class TestEmailSender implements EmailSender {
     private final Emails emails = new Emails();
 
     @Override
-    public void sendEmail(String recipient, String subject, String body) {
+    public void sendEmail(String recipient, String subject, String body, Attachment... attachments) {
         log.debug("Sending email to '{}', subject '{}', body '{}'", recipient, subject, body);
-        emails.add(recipient, subject, body);
+        emails.add(recipient, subject, body, attachments);
     }
 
     @Override
-    public void sendEmails(List<String> recipients, String subject, String body) {
+    public void sendEmails(List<String> recipients, String subject, String body, Attachment... attachments) {
         log.debug("Sending email to '{}', subject '{}', body '{}'", recipients, subject, body);
-        emails.add(new HashSet<>(recipients), subject, body);
+        emails.add(new HashSet<>(recipients), subject, body, attachments);
     }
 }

--- a/backend/src/test/java/de/qaware/mercury/test/fixtures/ReservationFixture.java
+++ b/backend/src/test/java/de/qaware/mercury/test/fixtures/ReservationFixture.java
@@ -8,8 +8,14 @@ import de.qaware.mercury.business.time.impl.WallClock;
 import de.qaware.mercury.business.uuid.UUIDFactory;
 import de.qaware.mercury.test.uuid.TestUUIDFactory;
 
+import java.util.UUID;
+
 public final class ReservationFixture {
     private ReservationFixture() {
+    }
+
+    public static Reservation create() {
+        return create(Shop.Id.of(UUID.randomUUID()));
     }
 
     public static Reservation create(Shop.Id shopId) {

--- a/backend/src/test/java/de/qaware/mercury/test/time/TestClock.java
+++ b/backend/src/test/java/de/qaware/mercury/test/time/TestClock.java
@@ -39,4 +39,13 @@ public class TestClock implements Clock {
     public ZonedDateTime nowZoned() {
         return now;
     }
+
+    /**
+     * Returns always the same datetime, '2020-04-26T18:51:52.387535+02:00[Europe/Berlin]'
+     *
+     * @return clock with a fixed datetime
+     */
+    public static TestClock fixed() {
+        return new TestClock(ZonedDateTime.parse("2020-04-26T18:51:52.387535+02:00[Europe/Berlin]"));
+    }
 }

--- a/backend/src/test/resources/icalendar/1.ics
+++ b/backend/src/test/resources/icalendar/1.ics
@@ -1,0 +1,13 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//lokaler.kaufen/lokaler.kaufen//EN
+BEGIN:VEVENT
+UID:830d9f5c-28c4-4bdf-b5d2-22f57c49bd64
+ORGANIZER;CN=The organizer:MAILTO:organizer@local.host
+DTSTAMP:20200426T165152Z
+DTSTART:20200426T170000
+DTEND:20200426T190000
+SUMMARY:This is the summary
+DESCRIPTION:This is the description\nAnd it contains a new line\nand several chars: \, \; \\
+END:VEVENT
+END:VCALENDAR


### PR DESCRIPTION
Hängt an die "new reservation" email an den Laden ein ICS mit dem Subject / Text der Mail an. Getestet mit Thunderbird & GMail.

Neue Konfigurationsmöglichkeiten:

```
mercury:
  ical:
    organizer-email: "noreply@lokaler.kaufen"
    organizer-name: "Lokaler.kaufen"
```